### PR TITLE
Remove broken placeholder links in past-sprints.md

### DIFF
--- a/files/docs/past-sprints.md
+++ b/files/docs/past-sprints.md
@@ -210,12 +210,12 @@ A big thank you goes out to all our participants:
 1. **Forms Development**
    - Audited and implemented existing form content in Google Forms
    - Created two specialized forms:
-     - [Sign up form for Salesforce Professionals](https://forms.gle/your-form-link) (Jr Admin & Tech Experts)
-     - [Interest Form for Charities](https://forms.gle/your-form-link)
+     - Sign up form for Salesforce Professionals (Jr Admin & Tech Experts)
+     - Interest Form for Charities
    - Designed for seamless onboarding process
 
 2. **Project Documentation**
-   - Created [TCC Project Documentation Spreadsheet](https://docs.google.com/spreadsheets/your-spreadsheet-link)
+   - Created TCC Project Documentation Spreadsheet
    - Features:
      - Centralized project management
      - Cross-platform compatibility (.xlsx format)
@@ -223,7 +223,7 @@ A big thank you goes out to all our participants:
      - Downloadable format for platform flexibility
 
 3. **Engagement Framework**
-   - Developed [Engagement Kick-Off Template](https://docs.google.com/document/your-template-link)
+   - Developed Engagement Kick-Off Template
    - Based on successful pilot project management presentation
    - Includes:
      - Ways of working
@@ -330,7 +330,7 @@ The February 2024 Virtual Sprint demonstrated remarkable progress with a small b
      - Framework to be developed
 
 ##### Documentation
-- [Sprint Working Document](https://docs.google.com/spreadsheets/your-sheet-link)
+- Sprint Working Document
 
 ##### Next Steps
 1. Complete website proofreading


### PR DESCRIPTION
## What & why
Five links in `past-sprints.md` pointed to placeholder URLs that were **live on the site and led nowhere**:

| Label | Was pointing to |
|-------|-----------------|
| Sign up form for Salesforce Professionals | `forms.gle/your-form-link` |
| Interest Form for Charities | `forms.gle/your-form-link` |
| TCC Project Documentation Spreadsheet | `docs.google.com/spreadsheets/your-spreadsheet-link` |
| Engagement Kick-Off Template | `docs.google.com/document/your-template-link` |
| Sprint Working Document | `docs.google.com/spreadsheets/your-sheet-link` |

Each is converted to **plain text**, preserving the descriptive label so the surrounding content still reads correctly. The team can re-link these once the real URLs are available.

## Verification
`mkdocs build --strict` → exit 0, no placeholder URLs remain anywhere in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)