### PR TITLE
Bump Pages actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,9 +17,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: pip
@@ -29,9 +29,9 @@ jobs:
 
       - run: mkdocs build --strict -d _site
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -45,5 +45,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deploy


### PR DESCRIPTION
## Why
GitHub is deprecating Node.js 20 on Actions runners — runners are **forced to Node 24 starting 2026-06-16** (tomorrow). Every recent deploy emitted a deprecation annotation naming `checkout`, `setup-python`, `configure-pages`, and `upload-artifact`. This bumps all Pages actions to the latest majors, which run on Node 24.

## Changes
| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | **v6** |
| actions/setup-python | v5 | **v6** |
| actions/configure-pages | v5 | **v6** |
| actions/upload-pages-artifact | v3 | **v5** |
| actions/deploy-pages | v4 | **v5** |

## Verification
- Confirmed each action's `action.yml` declares `using: node24` (upload-pages-artifact is a composite action wrapping the node24 `upload-artifact`).
- YAML validated.
- Action-version correctness can only be fully confirmed by a real run — will watch the deploy on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)