### PR TITLE
Add two application experiences to A/B test (redirect vs modal)

### DIFF
--- a/prototype/roles/charity-nonprofit.html
+++ b/prototype/roles/charity-nonprofit.html
@@ -139,15 +139,23 @@
         </div>
       </section>
 
-      <!-- CTA -->
+      <!-- CTA — A/B test: two application experiences.
+           (1) "new page" = redirect to the hosted FormTitan form.
+           (2) "here" = open the embedded form in a modal on this page. -->
       <section id="apply" class="rounded-3xl bg-gradient-to-br from-brand to-brand-dark text-white px-8 py-12 text-center shadow-xl shadow-brand/20">
         <h2 class="text-2xl sm:text-3xl font-bold">Get involved</h2>
         <p class="mt-3 text-white/85">Apply for Salesforce support for your organisation.</p>
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdTZLGZNBVQCvCrwX8W4gUbGqSC0Tj50fjrUQsF0rHKOIDDVQ/viewform"
-           target="_blank" rel="noopener"
-           class="mt-7 inline-block px-7 py-3.5 rounded-xl bg-white text-brand font-semibold hover:bg-slate-100 transition">
-          Apply for help for your organisation
-        </a>
+        <div class="mt-7 flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="https://titantc.formtitan.com/ftproject/ft1479d03a1fee41f2a384efa2e3c3a82b"
+             target="_blank" rel="noopener"
+             class="inline-block px-7 py-3.5 rounded-xl bg-white text-brand font-semibold hover:bg-slate-100 transition">
+            Apply — open in a new page
+          </a>
+          <button type="button" data-open-form
+             class="inline-block px-7 py-3.5 rounded-xl bg-brand-light/30 text-white font-semibold border border-white/40 hover:bg-brand-light/50 transition">
+            Apply — open form here
+          </button>
+        </div>
       </section>
 
       <p class="text-center text-slate-500">
@@ -197,6 +205,24 @@
     </div>
   </footer>
 
+  <!-- Application form modal (experience B). The FormTitan embed is injected only
+       when first opened, so the form's scripts don't load on every page view. -->
+  <div id="formModal" class="hidden fixed inset-0 z-50">
+    <div data-close-form class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"></div>
+    <div class="absolute inset-0 flex items-start sm:items-center justify-center p-4 overflow-y-auto">
+      <div role="dialog" aria-modal="true" aria-label="Application form"
+           class="relative w-full max-w-2xl my-8 bg-white rounded-2xl shadow-2xl">
+        <button type="button" data-close-form aria-label="Close form"
+          class="absolute -top-3 -right-3 h-9 w-9 flex items-center justify-center rounded-full bg-white border border-slate-200 shadow-md text-slate-600 hover:text-brand transition">
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"/></svg>
+        </button>
+        <div class="p-2 sm:p-4">
+          <div id="formModalBody" class="min-h-[300px]"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script>
     const navToggle = document.getElementById('navToggle');
     const navMenu = document.getElementById('navMenu');
@@ -209,6 +235,42 @@
     const wipClose = document.getElementById('wipClose');
     const wipBanner = document.getElementById('wipBanner');
     if (wipClose && wipBanner) wipClose.addEventListener('click', () => wipBanner.remove());
+
+    // ── Application form modal (experience B) ──────────────────────────────
+    (function () {
+      const modal = document.getElementById('formModal');
+      const body  = document.getElementById('formModalBody');
+      if (!modal || !body) return;
+      let loaded = false;
+
+      // Inject the FormTitan embed on first open. Scripts added via innerHTML
+      // don't execute, so we recreate each <script> for it to run.
+      const loadForm = () => {
+        if (loaded) return; loaded = true;
+        const guid = 'ft4f5357d7ba5d4b3d836917a4e42a73f2';
+        const project = 'ft1479d03a1fee41f2a384efa2e3c3a82b';
+        const mount = document.createElement('div');
+        mount.id = 'ftEmbedForm-' + guid;
+        body.appendChild(mount);
+        [
+          { src: 'https://d3v0iqf1i1i9dg.cloudfront.net/embed/v1/ftautosize.js', attrs: { 'data-ftguid': guid } },
+          { src: 'https://titantc.formtitan.com/publish/v1/embed?project=' + project + '&width=100%&height=700&guid=' + guid },
+        ].forEach((s) => {
+          const el = document.createElement('script');
+          el.type = 'text/javascript';
+          el.src = s.src;
+          Object.entries(s.attrs || {}).forEach(([k, v]) => el.setAttribute(k, v));
+          body.appendChild(el);
+        });
+      };
+
+      const open = () => { loadForm(); modal.classList.remove('hidden'); document.body.style.overflow = 'hidden'; };
+      const close = () => { modal.classList.add('hidden'); document.body.style.overflow = ''; };
+
+      document.querySelectorAll('[data-open-form]').forEach((b) => b.addEventListener('click', open));
+      modal.querySelectorAll('[data-close-form]').forEach((b) => b.addEventListener('click', close));
+      document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !modal.classList.contains('hidden')) close(); });
+    })();
   </script>
 </body>
 </html>

--- a/prototype/roles/junior-professional.html
+++ b/prototype/roles/junior-professional.html
@@ -139,14 +139,23 @@
         </div>
       </section>
 
+      <!-- CTA — A/B test: two application experiences.
+           (1) "new page" = redirect to the hosted FormTitan form.
+           (2) "here" = open the embedded form in a modal on this page. -->
       <section id="apply" class="rounded-3xl bg-gradient-to-br from-brand to-brand-dark text-white px-8 py-12 text-center shadow-xl shadow-brand/20">
         <h2 class="text-2xl sm:text-3xl font-bold">Get involved</h2>
         <p class="mt-3 text-white/85">Apply to join as a junior Salesforce professional.</p>
-        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdTZLGZNBVQCvCrwX8W4gUbGqSC0Tj50fjrUQsF0rHKOIDDVQ/viewform"
-           target="_blank" rel="noopener"
-           class="mt-7 inline-block px-7 py-3.5 rounded-xl bg-white text-brand font-semibold hover:bg-slate-100 transition">
-          Apply as a junior professional
-        </a>
+        <div class="mt-7 flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="https://titantc.formtitan.com/ftproject/ft1479d03a1fee41f2a384efa2e3c3a82b"
+             target="_blank" rel="noopener"
+             class="inline-block px-7 py-3.5 rounded-xl bg-white text-brand font-semibold hover:bg-slate-100 transition">
+            Apply — open in a new page
+          </a>
+          <button type="button" data-open-form
+             class="inline-block px-7 py-3.5 rounded-xl bg-brand-light/30 text-white font-semibold border border-white/40 hover:bg-brand-light/50 transition">
+            Apply — open form here
+          </button>
+        </div>
       </section>
 
       <p class="text-center text-slate-500">
@@ -195,6 +204,24 @@
     </div>
   </footer>
 
+  <!-- Application form modal (experience B). The FormTitan embed is injected only
+       when first opened, so the form's scripts don't load on every page view. -->
+  <div id="formModal" class="hidden fixed inset-0 z-50">
+    <div data-close-form class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"></div>
+    <div class="absolute inset-0 flex items-start sm:items-center justify-center p-4 overflow-y-auto">
+      <div role="dialog" aria-modal="true" aria-label="Application form"
+           class="relative w-full max-w-2xl my-8 bg-white rounded-2xl shadow-2xl">
+        <button type="button" data-close-form aria-label="Close form"
+          class="absolute -top-3 -right-3 h-9 w-9 flex items-center justify-center rounded-full bg-white border border-slate-200 shadow-md text-slate-600 hover:text-brand transition">
+          <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"/></svg>
+        </button>
+        <div class="p-2 sm:p-4">
+          <div id="formModalBody" class="min-h-[300px]"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script>
     const navToggle = document.getElementById('navToggle');
     const navMenu = document.getElementById('navMenu');
@@ -207,6 +234,42 @@
     const wipClose = document.getElementById('wipClose');
     const wipBanner = document.getElementById('wipBanner');
     if (wipClose && wipBanner) wipClose.addEventListener('click', () => wipBanner.remove());
+
+    // ── Application form modal (experience B) ──────────────────────────────
+    (function () {
+      const modal = document.getElementById('formModal');
+      const body  = document.getElementById('formModalBody');
+      if (!modal || !body) return;
+      let loaded = false;
+
+      // Inject the FormTitan embed on first open. Scripts added via innerHTML
+      // don't execute, so we recreate each <script> for it to run.
+      const loadForm = () => {
+        if (loaded) return; loaded = true;
+        const guid = 'ft4f5357d7ba5d4b3d836917a4e42a73f2';
+        const project = 'ft1479d03a1fee41f2a384efa2e3c3a82b';
+        const mount = document.createElement('div');
+        mount.id = 'ftEmbedForm-' + guid;
+        body.appendChild(mount);
+        [
+          { src: 'https://d3v0iqf1i1i9dg.cloudfront.net/embed/v1/ftautosize.js', attrs: { 'data-ftguid': guid } },
+          { src: 'https://titantc.formtitan.com/publish/v1/embed?project=' + project + '&width=100%&height=700&guid=' + guid },
+        ].forEach((s) => {
+          const el = document.createElement('script');
+          el.type = 'text/javascript';
+          el.src = s.src;
+          Object.entries(s.attrs || {}).forEach(([k, v]) => el.setAttribute(k, v));
+          body.appendChild(el);
+        });
+      };
+
+      const open = () => { loadForm(); modal.classList.remove('hidden'); document.body.style.overflow = 'hidden'; };
+      const close = () => { modal.classList.add('hidden'); document.body.style.overflow = ''; };
+
+      document.querySelectorAll('[data-open-form]').forEach((b) => b.addEventListener('click', open));
+      modal.querySelectorAll('[data-close-form]').forEach((b) => b.addEventListener('click', close));
+      document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && !modal.classList.contains('hidden')) close(); });
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
Sets up an A/B test of two application experiences on the **nonprofit** and **junior professional** pages. The single "Apply" button becomes two, both using the new **FormTitan** application form:

- **"Apply — open in a new page"** — redirect experience; opens the hosted FormTitan form in a new tab.
- **"Apply — open form here"** — modal experience; opens the embedded form in an on-page popup.

**Modal behavior:**
- The FormTitan embed is injected only on **first open**, so the form's third-party scripts don't load on every page view.
- Closes via the ✕ button, clicking the backdrop, or pressing **Esc**; body scroll is locked while open.

Note: both buttons point at the same FormTitan form — this tests the *experience* (redirect vs. inline), not different forms. Replaces the old Google Form link on these two pages.

Deploys to: `https://sfdo-community-sprints.github.io/The-Technical-Collective/prototype/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)