### PR TITLE
Relabel application buttons as Form 1 / Form 2

### DIFF
--- a/prototype/roles/charity-nonprofit.html
+++ b/prototype/roles/charity-nonprofit.html
@@ -149,11 +149,11 @@
           <a href="https://titantc.formtitan.com/ftproject/ft1479d03a1fee41f2a384efa2e3c3a82b"
              target="_blank" rel="noopener"
              class="inline-block px-7 py-3.5 rounded-xl bg-white text-brand font-semibold hover:bg-slate-100 transition">
-            Apply — open in a new page
+            Form 1
           </a>
           <button type="button" data-open-form
              class="inline-block px-7 py-3.5 rounded-xl bg-brand-light/30 text-white font-semibold border border-white/40 hover:bg-brand-light/50 transition">
-            Apply — open form here
+            Form 2
           </button>
         </div>
       </section>

--- a/prototype/roles/junior-professional.html
+++ b/prototype/roles/junior-professional.html
@@ -149,11 +149,11 @@
           <a href="https://titantc.formtitan.com/ftproject/ft1479d03a1fee41f2a384efa2e3c3a82b"
              target="_blank" rel="noopener"
              class="inline-block px-7 py-3.5 rounded-xl bg-white text-brand font-semibold hover:bg-slate-100 transition">
-            Apply — open in a new page
+            Form 1
           </a>
           <button type="button" data-open-form
              class="inline-block px-7 py-3.5 rounded-xl bg-brand-light/30 text-white font-semibold border border-white/40 hover:bg-brand-light/50 transition">
-            Apply — open form here
+            Form 2
           </button>
         </div>
       </section>


### PR DESCRIPTION
Renames the two A/B-test application buttons on the nonprofit and junior pages to neutral labels so the team can compare:

- **Form 1** — redirect experience (opens hosted FormTitan in a new tab)
- **Form 2** — modal experience (opens the embedded form on the page)

Same two underlying experiences as before; only the labels changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)