### PR TITLE
Make the application form modal much larger

### DIFF
--- a/prototype/roles/charity-nonprofit.html
+++ b/prototype/roles/charity-nonprofit.html
@@ -208,14 +208,14 @@
        when first opened, so the form's scripts don't load on every page view. -->
   <div id="formModal" class="hidden fixed inset-0 z-50">
     <div data-close-form class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"></div>
-    <div class="absolute inset-0 flex items-start sm:items-center justify-center p-4 overflow-y-auto">
+    <div class="absolute inset-0 flex items-stretch sm:items-center justify-center p-2 sm:p-4">
       <div role="dialog" aria-modal="true" aria-label="Application form"
-           class="relative w-full max-w-2xl my-8 bg-white rounded-2xl shadow-2xl">
+           class="relative flex flex-col w-full max-w-6xl h-full sm:h-[95vh] bg-white rounded-2xl shadow-2xl overflow-hidden">
         <button type="button" data-close-form aria-label="Close form"
-          class="absolute -top-3 -right-3 h-9 w-9 flex items-center justify-center rounded-full bg-white border border-slate-200 shadow-md text-slate-600 hover:text-brand transition">
+          class="absolute top-3 right-3 z-10 h-9 w-9 flex items-center justify-center rounded-full bg-white border border-slate-200 shadow-md text-slate-600 hover:text-brand transition">
           <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"/></svg>
         </button>
-        <div class="p-2 sm:p-4">
+        <div class="flex-1 overflow-y-auto p-3 sm:p-5 pt-14 sm:pt-14">
           <div id="formModalBody" class="min-h-[300px]"></div>
         </div>
       </div>

--- a/prototype/roles/junior-professional.html
+++ b/prototype/roles/junior-professional.html
@@ -207,14 +207,14 @@
        when first opened, so the form's scripts don't load on every page view. -->
   <div id="formModal" class="hidden fixed inset-0 z-50">
     <div data-close-form class="absolute inset-0 bg-slate-900/60 backdrop-blur-sm"></div>
-    <div class="absolute inset-0 flex items-start sm:items-center justify-center p-4 overflow-y-auto">
+    <div class="absolute inset-0 flex items-stretch sm:items-center justify-center p-2 sm:p-4">
       <div role="dialog" aria-modal="true" aria-label="Application form"
-           class="relative w-full max-w-2xl my-8 bg-white rounded-2xl shadow-2xl">
+           class="relative flex flex-col w-full max-w-6xl h-full sm:h-[95vh] bg-white rounded-2xl shadow-2xl overflow-hidden">
         <button type="button" data-close-form aria-label="Close form"
-          class="absolute -top-3 -right-3 h-9 w-9 flex items-center justify-center rounded-full bg-white border border-slate-200 shadow-md text-slate-600 hover:text-brand transition">
+          class="absolute top-3 right-3 z-10 h-9 w-9 flex items-center justify-center rounded-full bg-white border border-slate-200 shadow-md text-slate-600 hover:text-brand transition">
           <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" d="M6 6l12 12M18 6L6 18"/></svg>
         </button>
-        <div class="p-2 sm:p-4">
+        <div class="flex-1 overflow-y-auto p-3 sm:p-5 pt-14 sm:pt-14">
           <div id="formModalBody" class="min-h-[300px]"></div>
         </div>
       </div>


### PR DESCRIPTION
The Form 2 modal was capped at `max-w-2xl` (672px), which squeezed the FormTitan form and forced it into a cramped, reflowed layout.

Widened it to a near-fullscreen dialog — `max-w-6xl` (~1152px) and `95vh` tall — with the form scrolling inside. This gives the embed room to render at its natural desktop width so it no longer changes/reflows. Close (✕ / backdrop / Esc) still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)