### PR TITLE
Restore full-bleed hero, top-anchored to avoid cropping heads

### DIFF
--- a/prototype/faq.html
+++ b/prototype/faq.html
@@ -76,17 +76,18 @@
   </header>
 
   <main>
-    <section class="hero-gradient border-b border-slate-100">
-      <div class="max-w-6xl mx-auto px-5 py-12 sm:py-16 grid md:grid-cols-2 gap-8 md:gap-10 items-center">
-        <div>
+    <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
+      <img src="assets/heroes/faq.jpg" alt="" aria-hidden="true"
+           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+      <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
+      <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
+        <div class="max-w-xl">
           <nav class="text-sm text-slate-500 mb-4" aria-label="Breadcrumb">
             <a href="index.html" class="hover:text-brand">Home</a> <span class="mx-1.5">/</span> <span class="text-slate-700">FAQ</span>
           </nav>
           <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-slate-900 leading-tight">Frequently asked questions</h1>
           <p class="mt-5 text-lg text-slate-700">Everything you need to know about the program.</p>
         </div>
-        <img src="assets/heroes/faq.jpg" alt="" aria-hidden="true"
-             class="w-full rounded-2xl shadow-lg ring-1 ring-slate-200/60" />
       </div>
     </section>
 

--- a/prototype/promises-expectations.html
+++ b/prototype/promises-expectations.html
@@ -73,17 +73,18 @@
   </header>
 
   <main>
-    <section class="hero-gradient border-b border-slate-100">
-      <div class="max-w-6xl mx-auto px-5 py-12 sm:py-16 grid md:grid-cols-2 gap-8 md:gap-10 items-center">
-        <div>
+    <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
+      <img src="assets/heroes/promises.jpg" alt="" aria-hidden="true"
+           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+      <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
+      <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
+        <div class="max-w-xl">
           <nav class="text-sm text-slate-500 mb-4" aria-label="Breadcrumb">
             <a href="index.html" class="hover:text-brand">Home</a> <span class="mx-1.5">/</span> <span class="text-slate-700">Promises &amp; Expectations</span>
           </nav>
           <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-slate-900 leading-tight">Promises &amp; Expectations</h1>
           <p class="mt-5 text-lg text-slate-700">The commitments each group makes to one another — the foundation of a successful, respectful partnership.</p>
         </div>
-        <img src="assets/heroes/promises.jpg" alt="" aria-hidden="true"
-             class="w-full rounded-2xl shadow-lg ring-1 ring-slate-200/60" />
       </div>
     </section>
 

--- a/prototype/roles/charity-nonprofit.html
+++ b/prototype/roles/charity-nonprofit.html
@@ -74,9 +74,12 @@
 
   <main>
     <!-- Page hero -->
-    <section class="hero-gradient border-b border-slate-100">
-      <div class="max-w-6xl mx-auto px-5 py-12 sm:py-16 grid md:grid-cols-2 gap-8 md:gap-10 items-center">
-        <div>
+    <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
+      <img src="../assets/heroes/nonprofits.jpg" alt="" aria-hidden="true"
+           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+      <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
+      <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
+        <div class="max-w-xl">
           <nav class="text-sm text-slate-500 mb-4" aria-label="Breadcrumb">
             <a href="../index.html" class="hover:text-brand">Home</a> <span class="mx-1.5">/</span> <span class="text-slate-700">Nonprofits &amp; Charities</span>
           </nav>
@@ -86,8 +89,6 @@
             You are a nonprofit organisation in need of Salesforce support. Look no further than The Technical Collective.
           </p>
         </div>
-        <img src="../assets/heroes/nonprofits.jpg" alt="" aria-hidden="true"
-             class="w-full rounded-2xl shadow-lg ring-1 ring-slate-200/60" />
       </div>
     </section>
 

--- a/prototype/roles/junior-professional.html
+++ b/prototype/roles/junior-professional.html
@@ -73,9 +73,12 @@
   </header>
 
   <main>
-    <section class="hero-gradient border-b border-slate-100">
-      <div class="max-w-6xl mx-auto px-5 py-12 sm:py-16 grid md:grid-cols-2 gap-8 md:gap-10 items-center">
-        <div>
+    <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
+      <img src="../assets/heroes/juniors.jpg" alt="" aria-hidden="true"
+           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+      <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
+      <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
+        <div class="max-w-xl">
           <nav class="text-sm text-slate-500 mb-4" aria-label="Breadcrumb">
             <a href="../index.html" class="hover:text-brand">Home</a> <span class="mx-1.5">/</span> <span class="text-slate-700">Junior Professionals</span>
           </nav>
@@ -85,8 +88,6 @@
             You are a certified Salesforce professional looking for an exciting opportunity to gain hands-on experience and make a difference in the nonprofit sector.
           </p>
         </div>
-        <img src="../assets/heroes/juniors.jpg" alt="" aria-hidden="true"
-             class="w-full rounded-2xl shadow-lg ring-1 ring-slate-200/60" />
       </div>
     </section>
 

--- a/prototype/roles/technical-expert.html
+++ b/prototype/roles/technical-expert.html
@@ -73,9 +73,12 @@
   </header>
 
   <main>
-    <section class="hero-gradient border-b border-slate-100">
-      <div class="max-w-6xl mx-auto px-5 py-12 sm:py-16 grid md:grid-cols-2 gap-8 md:gap-10 items-center">
-        <div>
+    <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
+      <img src="../assets/heroes/experts.jpg" alt="" aria-hidden="true"
+           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+      <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
+      <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
+        <div class="max-w-xl">
           <nav class="text-sm text-slate-500 mb-4" aria-label="Breadcrumb">
             <a href="../index.html" class="hover:text-brand">Home</a> <span class="mx-1.5">/</span> <span class="text-slate-700">Technical Experts</span>
           </nav>
@@ -85,8 +88,6 @@
             You are an experienced Salesforce professional looking to give back to the community. This is your chance to make a real difference!
           </p>
         </div>
-        <img src="../assets/heroes/experts.jpg" alt="" aria-hidden="true"
-             class="w-full rounded-2xl shadow-lg ring-1 ring-slate-200/60" />
       </div>
     </section>
 


### PR DESCRIPTION
Reverts to the **full-bleed background** hero style (preferred over the two-column panel), but fixes the original head-cropping problem.

## Fix
- Image anchored to the **top** (`object-right-top`) instead of center → faces/heads are always kept
- Taller banner (`min-h-[460px]`) so less of the scene is cut
- Any cropping now falls at the **bottom** of the illustration (tables, laptops), not on people
- White→transparent gradient on the left keeps the heading/text legible

Applies to all 5 inner pages. Home page unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)