### PR TITLE
Shift hero focal point down to reduce empty top space

### DIFF
--- a/prototype/faq.html
+++ b/prototype/faq.html
@@ -78,7 +78,7 @@
   <main>
     <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
       <img src="assets/heroes/faq.jpg" alt="" aria-hidden="true"
-           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+           class="absolute inset-0 h-full w-full object-cover object-[right_28%]" />
       <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
       <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
         <div class="max-w-xl">

--- a/prototype/promises-expectations.html
+++ b/prototype/promises-expectations.html
@@ -75,7 +75,7 @@
   <main>
     <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
       <img src="assets/heroes/promises.jpg" alt="" aria-hidden="true"
-           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+           class="absolute inset-0 h-full w-full object-cover object-[right_28%]" />
       <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
       <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
         <div class="max-w-xl">

--- a/prototype/roles/charity-nonprofit.html
+++ b/prototype/roles/charity-nonprofit.html
@@ -76,7 +76,7 @@
     <!-- Page hero -->
     <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
       <img src="../assets/heroes/nonprofits.jpg" alt="" aria-hidden="true"
-           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+           class="absolute inset-0 h-full w-full object-cover object-[right_28%]" />
       <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
       <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
         <div class="max-w-xl">

--- a/prototype/roles/junior-professional.html
+++ b/prototype/roles/junior-professional.html
@@ -75,7 +75,7 @@
   <main>
     <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
       <img src="../assets/heroes/juniors.jpg" alt="" aria-hidden="true"
-           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+           class="absolute inset-0 h-full w-full object-cover object-[right_28%]" />
       <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
       <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
         <div class="max-w-xl">

--- a/prototype/roles/technical-expert.html
+++ b/prototype/roles/technical-expert.html
@@ -75,7 +75,7 @@
   <main>
     <section class="relative border-b border-slate-100 overflow-hidden bg-slate-50 min-h-[460px] flex items-center">
       <img src="../assets/heroes/experts.jpg" alt="" aria-hidden="true"
-           class="absolute inset-0 h-full w-full object-cover object-right-top" />
+           class="absolute inset-0 h-full w-full object-cover object-[right_28%]" />
       <div class="absolute inset-0 bg-gradient-to-r from-white from-35% via-white/85 to-transparent"></div>
       <div class="relative w-full max-w-6xl mx-auto px-5 py-14">
         <div class="max-w-xl">


### PR DESCRIPTION
Follow-up tweak: the top-anchored heroes showed too much empty space above the people.

Moved the vertical focal point from `top` (0%) to **28%** (`object-[right_28%]`), so the framing sits higher on the subjects — less dead space up top, faces still safely uncropped. Applies to all 5 inner pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)