### PR TITLE
Add "Our Vision" section to the homepage

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -186,6 +186,42 @@
       </div>
     </section>
 
+    <!-- ─────────── Our Vision (win-win-win ecosystem) ─────────── -->
+    <section id="vision" class="py-20 border-t border-slate-100">
+      <div class="max-w-5xl mx-auto px-5">
+        <div class="text-center">
+          <span class="inline-block mb-4 px-3 py-1 rounded-full bg-brand/10 text-brand text-xs font-semibold tracking-wide uppercase">Our Vision</span>
+          <h2 class="text-3xl font-bold text-slate-900 reveal">A win-win-win ecosystem</h2>
+          <p class="mt-4 max-w-2xl mx-auto text-slate-600 reveal">
+            The Technical Collective aims to create value for everyone it touches.
+          </p>
+        </div>
+
+        <div class="mt-12 grid sm:grid-cols-2 gap-6">
+          <!-- Inexperienced admins -->
+          <div class="reveal bg-slate-50 rounded-2xl border border-slate-200 border-l-4 border-l-accent p-7">
+            <h3 class="font-bold text-slate-900">For inexperienced admins</h3>
+            <p class="mt-2 text-slate-600">Provide a clear pathway to gain real-world project experience while being mentored by seasoned professionals.</p>
+          </div>
+          <!-- Experienced professionals -->
+          <div class="reveal bg-slate-50 rounded-2xl border border-slate-200 border-l-4 border-l-brand-light p-7">
+            <h3 class="font-bold text-slate-900">For experienced professionals</h3>
+            <p class="mt-2 text-slate-600">Offer a meaningful opportunity to give back to the community, mentor upcoming talent, and support non-profits.</p>
+          </div>
+          <!-- Non-profits -->
+          <div class="reveal bg-slate-50 rounded-2xl border border-slate-200 border-l-4 border-l-brand p-7">
+            <h3 class="font-bold text-slate-900">For non-profits</h3>
+            <p class="mt-2 text-slate-600">Help charities maximise their Salesforce investment and impact, all while minimising technical debt.</p>
+          </div>
+          <!-- Ecosystem -->
+          <div class="reveal bg-slate-50 rounded-2xl border border-slate-200 border-l-4 border-l-accent-dark p-7">
+            <h3 class="font-bold text-slate-900">For the ecosystem</h3>
+            <p class="mt-2 text-slate-600">Bridge the technical skills gap in the Salesforce community.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- ─────────── Role cards (concise teasers → link to role pages) ─────────── -->
     <section id="roles" class="py-20 bg-slate-50 border-t border-slate-100">
       <div class="max-w-6xl mx-auto px-5">


### PR DESCRIPTION
Adds an **Our Vision** section to the homepage, placed right after "One problem, three sides" (problem → vision flows naturally).

States the win-win-win ecosystem as four cards:
- **For inexperienced admins** — a clear pathway to real-world experience, mentored by seasoned pros.
- **For experienced professionals** — a meaningful way to give back, mentor talent, and support non-profits.
- **For non-profits** — maximise their Salesforce investment and impact while minimising technical debt.
- **For the ecosystem** — bridge the technical skills gap in the Salesforce community.

Matches the existing design language; each card has a distinct brand/accent left border. Nav left unchanged to avoid crowding (the section sits high on the page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)