### PR TITLE
Add "Our Vision" content to the homepage hero

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -135,9 +135,26 @@
           Upskill. Volunteer. <span class="text-brand">Impact.</span>
         </h1>
         <p class="mt-6 max-w-2xl mx-auto text-lg sm:text-xl text-slate-600">
-          A volunteer program that pairs nonprofits with junior Salesforce admins —
-          mentored by seasoned experts — to deliver real projects that grow careers and missions.
+          Our vision is to create a <span class="font-semibold text-slate-900">win-win-win ecosystem</span> across the Salesforce community.
         </p>
+        <dl class="mt-8 max-w-3xl mx-auto grid sm:grid-cols-2 gap-x-8 gap-y-4 text-left">
+          <div>
+            <dt class="font-semibold text-slate-900">Inexperienced admins</dt>
+            <dd class="text-sm text-slate-600">A clear pathway to gain real-world project experience, mentored by seasoned professionals.</dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-slate-900">Experienced professionals</dt>
+            <dd class="text-sm text-slate-600">A meaningful way to give back to the community, mentor upcoming talent, and support nonprofits.</dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-slate-900">Nonprofits</dt>
+            <dd class="text-sm text-slate-600">Help to maximise their Salesforce investment and impact, while minimising technical debt.</dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-slate-900">The ecosystem</dt>
+            <dd class="text-sm text-slate-600">Bridging the technical skills gap across the wider Salesforce community.</dd>
+          </div>
+        </dl>
         <div class="mt-9 flex flex-col sm:flex-row gap-3 justify-center">
           <a href="#apply" class="px-7 py-3.5 rounded-xl bg-brand text-white font-semibold hover:bg-brand-dark transition shadow-lg shadow-brand/20">
             Find your role


### PR DESCRIPTION
Replaces the short hero subtitle with the project's **Our Vision** statement (the win-win-win ecosystem), as requested.

Laid out as a centered lead line + a two-column grid of the four audience benefits (inexperienced admins, experienced professionals, nonprofits, the ecosystem) so the hero stays balanced rather than a wall of text. Content sourced from the project README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)