### PR TITLE
Add "For everyone" label to Promises & FAQ heroes

### DIFF
--- a/prototype/faq.html
+++ b/prototype/faq.html
@@ -85,6 +85,7 @@
           <nav class="text-sm text-slate-500 mb-4" aria-label="Breadcrumb">
             <a href="index.html" class="hover:text-brand">Home</a> <span class="mx-1.5">/</span> <span class="text-slate-700">FAQ</span>
           </nav>
+          <span class="inline-block mb-4 px-3 py-1 rounded-full bg-brand/10 text-brand text-xs font-semibold tracking-wide uppercase">For everyone</span>
           <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-slate-900 leading-tight">Frequently asked questions</h1>
           <p class="mt-5 text-lg text-slate-700">Everything you need to know about the program.</p>
         </div>

--- a/prototype/promises-expectations.html
+++ b/prototype/promises-expectations.html
@@ -82,6 +82,7 @@
           <nav class="text-sm text-slate-500 mb-4" aria-label="Breadcrumb">
             <a href="index.html" class="hover:text-brand">Home</a> <span class="mx-1.5">/</span> <span class="text-slate-700">Promises &amp; Expectations</span>
           </nav>
+          <span class="inline-block mb-4 px-3 py-1 rounded-full bg-brand/10 text-brand text-xs font-semibold tracking-wide uppercase">For everyone</span>
           <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-slate-900 leading-tight">Promises &amp; Expectations</h1>
           <p class="mt-5 text-lg text-slate-700">The commitments each group makes to one another — the foundation of a successful, respectful partnership.</p>
         </div>


### PR DESCRIPTION
The role pages each show a category pill (e.g. "FOR TECHNICAL EXPERTS"), but the **Promises** and **FAQ** pages had none. Since those serve all three audiences, added a matching **"For everyone"** pill to both heroes for visual consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)