### PR TITLE
Rename "Our Vision" label to "Our Mission"

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -207,7 +207,7 @@
     <section id="vision" class="py-20 border-t border-slate-100">
       <div class="max-w-5xl mx-auto px-5">
         <div class="text-center">
-          <span class="inline-block mb-4 px-3 py-1 rounded-full bg-brand/10 text-brand text-xs font-semibold tracking-wide uppercase">Our Vision</span>
+          <span class="inline-block mb-4 px-3 py-1 rounded-full bg-brand/10 text-brand text-xs font-semibold tracking-wide uppercase">Our Mission</span>
           <h2 class="text-3xl font-bold text-slate-900 reveal">A win-win-win ecosystem</h2>
           <p class="mt-4 max-w-2xl mx-auto text-slate-600 reveal">
             The Technical Collective aims to create value for everyone it touches.


### PR DESCRIPTION
Changes the pill label on the win-win-win ecosystem section from **"Our Vision"** to **"Our Mission"**, as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)