### PR TITLE
Match Juniors hero pill color to other pages

### DIFF
--- a/prototype/roles/junior-professional.html
+++ b/prototype/roles/junior-professional.html
@@ -82,7 +82,7 @@
           <nav class="text-sm text-slate-500 mb-4" aria-label="Breadcrumb">
             <a href="../index.html" class="hover:text-brand">Home</a> <span class="mx-1.5">/</span> <span class="text-slate-700">Junior Professionals</span>
           </nav>
-          <span class="inline-block mb-4 px-3 py-1 rounded-full bg-accent/10 text-accent-dark text-xs font-semibold tracking-wide uppercase">For junior professionals</span>
+          <span class="inline-block mb-4 px-3 py-1 rounded-full bg-brand/10 text-brand text-xs font-semibold tracking-wide uppercase">For junior professionals</span>
           <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight text-slate-900 leading-tight">Gain real experience, with mentorship</h1>
           <p class="mt-5 text-lg text-slate-700">
             You are a certified Salesforce professional looking for an exciting opportunity to gain hands-on experience and make a difference in the nonprofit sector.


### PR DESCRIPTION
The Junior Professionals hero pill was teal (accent) while all other hero pills are indigo (brand). Changed it to match for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)