### PR TITLE
Remove duplicate win-win-win content from hero

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -135,26 +135,9 @@
           Upskill. Volunteer. <span class="text-brand">Impact.</span>
         </h1>
         <p class="mt-6 max-w-2xl mx-auto text-lg sm:text-xl text-slate-600">
-          Our vision is to create a <span class="font-semibold text-slate-900">win-win-win ecosystem</span> across the Salesforce community.
+          A volunteer program that pairs nonprofits with junior Salesforce admins —
+          mentored by seasoned experts — to deliver real projects that grow careers and missions.
         </p>
-        <dl class="mt-8 max-w-3xl mx-auto grid sm:grid-cols-2 gap-x-8 gap-y-4 text-left">
-          <div>
-            <dt class="font-semibold text-slate-900">Inexperienced admins</dt>
-            <dd class="text-sm text-slate-600">A clear pathway to gain real-world project experience, mentored by seasoned professionals.</dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-slate-900">Experienced professionals</dt>
-            <dd class="text-sm text-slate-600">A meaningful way to give back to the community, mentor upcoming talent, and support nonprofits.</dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-slate-900">Nonprofits</dt>
-            <dd class="text-sm text-slate-600">Help to maximise their Salesforce investment and impact, while minimising technical debt.</dd>
-          </div>
-          <div>
-            <dt class="font-semibold text-slate-900">The ecosystem</dt>
-            <dd class="text-sm text-slate-600">Bridging the technical skills gap across the wider Salesforce community.</dd>
-          </div>
-        </dl>
         <div class="mt-9 flex flex-col sm:flex-row gap-3 justify-center">
           <a href="#apply" class="px-7 py-3.5 rounded-xl bg-brand text-white font-semibold hover:bg-brand-dark transition shadow-lg shadow-brand/20">
             Find your role
@@ -203,7 +186,7 @@
       </div>
     </section>
 
-    <!-- ─────────── Our Vision (win-win-win ecosystem) ─────────── -->
+    <!-- ─────────── Our Mission (win-win-win ecosystem) ─────────── -->
     <section id="vision" class="py-20 border-t border-slate-100">
       <div class="max-w-5xl mx-auto px-5">
         <div class="text-center">


### PR DESCRIPTION
The win-win-win ecosystem content was showing **twice** on the homepage — once as a grid in the hero, and once as the dedicated **Our Mission** card section.

This reverts the hero back to its concise one-line subtitle, keeping the polished card section as the single home for that content. Also fixes a stale code comment ("Our Vision" → "Our Mission").

🤖 Generated with [Claude Code](https://claude.com/claude-code)