### PR TITLE
Add CNAME so custom domain survives deploys

### DIFF
--- a/files/docs/CNAME
+++ b/files/docs/CNAME
@@ -1,0 +1,1 @@
+www.technicalcollective.org


### PR DESCRIPTION
Sets up the custom domain **www.technicalcollective.org** to persist across deploys.

## Why
Pages is built by a GitHub Actions workflow (`mkdocs build -d _site` → upload `_site`). A `CNAME` file at the repo root (which GitHub adds when you set the domain in Settings) is **not** part of the MkDocs build output, so it gets dropped on the next deploy and the custom domain disconnects.

## Fix
Place `CNAME` in the docs source (`files/docs/CNAME`). MkDocs copies everything in the docs dir into `_site`, so the `CNAME` is included in every build. Verified locally that the build output contains it.

## Still required (DNS — done in Vercel, not here)
- `www` → CNAME → `sfdo-community-sprints.github.io`
- apex `@` → the 4 GitHub Pages A records
- Then enable **Enforce HTTPS** in Settings → Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)