### PR TITLE
Remove CNAME while custom domain is parked

### DIFF
--- a/files/docs/CNAME
+++ b/files/docs/CNAME
@@ -1,1 +1,0 @@
-www.technicalcollective.org


### PR DESCRIPTION
The custom domain is currently unset in GitHub Pages (we'll do the Vercel DNS later). Removing `files/docs/CNAME` so it isn't baked into every build — this avoids GitHub re-attaching and then dropping the unverified domain. I'll re-add it in one step when DNS is ready.

The site stays on the github.io URLs, working normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)