### PR TITLE
Promote prototype to site root, keep docs at /docs/

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,12 +27,13 @@ jobs:
 
       - run: pip install -r requirements.txt
 
-      - run: mkdocs build --strict -d _site
+      # The next-version prototype is now the main site (served at the root).
+      # The original MkDocs documentation site is preserved under /docs/.
+      - name: Build MkDocs site into /docs/
+        run: mkdocs build --strict -d _site/docs
 
-      # Publish the next-version prototype alongside the live site, under /prototype/.
-      # This runs after the MkDocs build so it can't affect the main site output.
-      - name: Copy prototype into site output
-        run: cp -r prototype _site/prototype
+      - name: Publish prototype at the site root
+        run: cp -r prototype/. _site/
 
       - uses: actions/configure-pages@v6
 


### PR DESCRIPTION
Brings the next-version prototype **live as the main site**, while preserving the original MkDocs documentation site at **/docs/** (nothing lost).

## Change (deploy workflow only)
- MkDocs now builds into `_site/docs` → served at `/docs/`
- Prototype contents are copied to the site **root** (`_site/`) → served at `/`

## Result
| URL | Content |
|-----|---------|
| `/` | New prototype homepage |
| `/roles/*.html`, `/faq.html`, `/promises-expectations.html` | Prototype pages |
| `/docs/` | Original MkDocs site (preserved) |

Verified locally: the build produces root = prototype, `/docs/` = MkDocs. Prototype links are all relative, so they work correctly at the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)