### PR TITLE
Add server-side spam guards to form intake

### DIFF
--- a/prototype/assets/tc-forms.js
+++ b/prototype/assets/tc-forms.js
@@ -215,6 +215,10 @@
     var busy = host.querySelector('[data-form-busy]');
     var submitBtn = form.querySelector('button[type="submit"]');
 
+    // Spam timing trap: record when the form became available; the elapsed time
+    // is sent on submit so the server can drop instant (bot) submissions.
+    var renderedAt = Date.now();
+
     form.addEventListener('submit', function (e) {
       e.preventDefault();
       errBox.classList.add('hidden');
@@ -227,6 +231,7 @@
 
       var payload = collect(form);
       payload.formType = type;
+      payload.elapsedMs = Date.now() - renderedAt;
 
       submitBtn.disabled = true;
       busy.classList.remove('hidden');

--- a/salesforce/tc-forms/force-app/main/default/classes/TC_FormIntake.cls
+++ b/salesforce/tc-forms/force-app/main/default/classes/TC_FormIntake.cls
@@ -16,6 +16,11 @@
 @RestResource(urlMapping='/tc/intake')
 global without sharing class TC_FormIntake {
 
+    // Submissions completed faster than this (milliseconds) are treated as bots.
+    private static final Decimal MIN_ELAPSED_MS = 2500;
+    // A given email may only create one record within this window (hours).
+    private static final Integer DEDUPE_WINDOW_HOURS = 24;
+
     // ---- response shape ------------------------------------------------------
     global class Result {
         global Boolean success;
@@ -44,11 +49,27 @@ global without sharing class TC_FormIntake {
             return new Result(false, 'Empty request.');
         }
 
-        // Honeypot: real users never fill this hidden field. Pretend success.
+        // --- Spam guards -----------------------------------------------------
+        // 1. Honeypot: real users never fill this hidden field. Pretend success
+        //    so a bot can't tell it was rejected.
         String honeypot = str(body.get('website_url2'));
         if (String.isNotBlank(honeypot)) {
             res.statusCode = 200;
             return new Result(true, 'Thank you for your submission!');
+        }
+
+        // 2. Timing trap: the form reports how long the user spent before
+        //    submitting (elapsedMs). A human takes seconds; bots post instantly.
+        //    Too-fast submissions are silently accepted-looking but dropped.
+        Object elapsedRaw = body.get('elapsedMs');
+        if (elapsedRaw != null) {
+            try {
+                Decimal elapsed = Decimal.valueOf(String.valueOf(elapsedRaw));
+                if (elapsed < MIN_ELAPSED_MS) {
+                    res.statusCode = 200;
+                    return new Result(true, 'Thank you for your submission!');
+                }
+            } catch (Exception ignore) { /* unparseable -> ignore the trap */ }
         }
 
         String formType = str(body.get('formType')).toLowerCase();
@@ -81,6 +102,12 @@ global without sharing class TC_FormIntake {
         if (!looksLikeEmail(email)) {
             res.statusCode = 400;
             return new Result(false, 'Please enter a valid email address.');
+        }
+        // Dedupe: this email already applied recently -> look successful, skip insert.
+        if (recentlySubmitted(email)) {
+            Result dup = new Result(true, 'Thank you — we already have your submission and will be in touch.');
+            res.statusCode = 200;
+            return dup;
         }
 
         Account acc = new Account();
@@ -148,6 +175,12 @@ global without sharing class TC_FormIntake {
             res.statusCode = 400;
             return new Result(false, 'Please enter a valid email address.');
         }
+        // Dedupe: this email already applied recently -> look successful, skip insert.
+        if (recentlySubmitted(email)) {
+            Result dup = new Result(true, 'Thank you — we already have your submission and will be in touch.');
+            res.statusCode = 200;
+            return dup;
+        }
 
         Contact c = new Contact();
         c.FirstName = firstName;
@@ -191,6 +224,18 @@ global without sharing class TC_FormIntake {
 
     private static Boolean looksLikeEmail(String e) {
         return String.isNotBlank(e) && Pattern.matches('^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$', e);
+    }
+
+    // True if a Contact with this email was created within the dedupe window.
+    // Limits the same address (or a bot replaying one payload) to one record.
+    private static Boolean recentlySubmitted(String email) {
+        if (String.isBlank(email)) return false;
+        Datetime cutoff = Datetime.now().addHours(-DEDUPE_WINDOW_HOURS);
+        return [
+            SELECT COUNT()
+            FROM Contact
+            WHERE Email = :email AND CreatedDate >= :cutoff
+        ] > 0;
     }
 
     // Set a field only when there's a value, and trim to the field's max length.

--- a/salesforce/tc-forms/force-app/main/default/classes/TC_FormIntakeTest.cls
+++ b/salesforce/tc-forms/force-app/main/default/classes/TC_FormIntakeTest.cls
@@ -102,6 +102,44 @@ private class TC_FormIntakeTest {
     }
 
     @IsTest
+    static void timingTrap_tooFast_dropsRecord() {
+        Integer before = [SELECT COUNT() FROM Contact];
+        TC_FormIntake.Result r = invoke(new Map<String, Object>{
+            'formType' => 'professional', 'lastName' => 'Speedy', 'email' => 'fast@example.com',
+            'elapsedMs' => 200   // way under the 2500ms threshold -> treated as a bot
+        });
+        System.assertEquals(true, r.success);                       // looks successful to the bot
+        System.assertEquals(before, [SELECT COUNT() FROM Contact]); // but nothing was created
+    }
+
+    @IsTest
+    static void timingTrap_humanSpeed_succeeds() {
+        TC_FormIntake.Result r = invoke(new Map<String, Object>{
+            'formType' => 'professional', 'lastName' => 'Human', 'email' => 'human@example.com',
+            'elapsedMs' => 9000
+        });
+        System.assertEquals(true, r.success, r.message);
+        System.assertNotEquals(null, r.contactId);
+    }
+
+    @IsTest
+    static void dedupe_sameEmailWithinWindow_skipsSecondInsert() {
+        Map<String, Object> b = new Map<String, Object>{
+            'formType' => 'professional', 'lastName' => 'Twice', 'email' => 'twice@example.com'
+        };
+        Test.startTest();
+        TC_FormIntake.Result first  = invoke(b);
+        TC_FormIntake.Result second = invoke(b);   // same email again
+        Test.stopTest();
+
+        System.assertEquals(true, first.success);
+        System.assertNotEquals(null, first.contactId);
+        System.assertEquals(true, second.success);          // still looks successful
+        System.assertEquals(null, second.contactId);        // but no new record
+        System.assertEquals(1, [SELECT COUNT() FROM Contact WHERE Email = 'twice@example.com']);
+    }
+
+    @IsTest
     static void unknownType_fails() {
         TC_FormIntake.Result r = invoke(new Map<String, Object>{ 'formType' => 'nope' });
         System.assertEquals(false, r.success);


### PR DESCRIPTION
Hardens the public form intake against bots/spam, **server-side** (the part that can't be bypassed).

## Why server-side
The intake endpoint is public and unauthenticated — browser-only protection (honeypot, even CAPTCHA) can be skipped by posting JSON directly with `curl`. So the accept/reject decision lives in the Apex.

## Guards added (`TC_FormIntake.cls`)
1. **Timing trap** — the form now sends `elapsedMs` (time since it rendered); submissions completed in under 2.5s are treated as bots — dropped, but returned as a fake success so the bot can't tell.
2. **Per-email dedupe** — an email that already created a Contact in the last 24h is skipped. Stops the payload-replay flood (the exact attack used during testing).
3. **Honeypot** — retained as-is.

Front end (`tc-forms.js`): captures a render timestamp and sends `elapsedMs` on submit. No other behavior change.

## Verification
- Deployed to the org: **10/10 Apex tests pass** (added tests for fast-bot, human-speed, and dedupe).
- Live `curl` test confirmed: an instant submission and a duplicate-email submission both create **no record** (verified in-org, then test data cleaned up).

## Note
This modifies the `tc-forms` Apex (owned by whoever built the form integration) — worth a heads-up to them. It's additive and backward-compatible: real form submissions are unaffected.

## Not included (discussed, deferred)
Cloudflare Turnstile (server-verified CAPTCHA) is the strongest option and the only thing that truly distinguishes a real browser from `curl`. This Apex hardening caps the damage (floods/dupes/instant bots) without any external dependency; Turnstile can be layered on later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)